### PR TITLE
Add basic prefers-color-scheme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
       </div>
 
   <script>
+    const isPrefersColorSupportted = () => {
+      const pcsDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+      const pcsLight = window.matchMedia("(prefers-color-scheme: light)").matches
+      return pcsDark != pcsLight
+    }
 
     const pressedButtonSelector = '[data-theme][aria-pressed="true"]';
     const prefersColorMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
@@ -50,7 +55,9 @@
     }
     
     const setDefaultTheme = () => {
-      themes.default = (prefersColorMediaQuery.matches === true) ? themes.dark : themes.light
+      if (isPrefersColorSupportted() === true) {
+        themes.default = (prefersColorMediaQuery.matches === true) ? themes.dark : themes.light
+      }
     }
 
     const applyInitialTheme = () => {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
       </div>
       <p>Find the tutorial soon on <a href="https://fossheim.io">fossheim.io</a></p>
       </div>
-    </body>
 
   <script>
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,13 @@
   <script>
 
     const pressedButtonSelector = '[data-theme][aria-pressed="true"]';
-    const defaultTheme = 'green';
+    const prefersColorMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const themes = {
+      saved: localStorage.getItem('selected-theme'),
+      dark: 'blue', // Theme to load when prefers-colors-scheme = light
+      light: 'pink', // Theme to load when prefers-colors-scheme = dark
+      default: 'orange' // Theme to load when prefers-colors-scheme isn’t supported
+    };
 
     const applyTheme = (theme) => {
       const target = document.querySelector(`[data-theme="${theme}"]`);
@@ -43,21 +49,32 @@
         localStorage.setItem('selected-theme', theme);
       }
     }
+    
+    const setDefaultTheme = () => {
+      themes.default = (prefersColorMediaQuery.matches === true) ? themes.dark : themes.light
+    }
 
-    const setInitialTheme = () => {
-      const savedTheme = localStorage.getItem('selected-theme');
-      if(savedTheme && savedTheme !== defaultTheme) {
-        applyTheme(savedTheme);
+    const applyInitialTheme = () => {
+      if(themes.saved && themes.saved !== themes.default) {
+        applyTheme(themes.saved);
+        return;
       }
+      applyTheme(themes.default);
     };
 
-    setInitialTheme();
+    setDefaultTheme();
+    applyInitialTheme();
 
     const themeSwitcher = document.querySelector('.theme-switcher');
     const buttons = themeSwitcher.querySelectorAll('button');
 
     buttons.forEach((button) => {
       button.addEventListener('click', handleThemeSelection);
+    });
+    
+    prefersColorMediaQuery.addEventListener('change', () => {
+      setDefaultTheme();
+      applyInitialTheme();
     });
 
 


### PR DESCRIPTION
Add support for `prefers-color-scheme` (PCS).

Settings, you can set which theme should be used:
- by default (in case PCS isn’t supported)
- for dark mode
- for light mode

Supports live switching theme when PCS changes.

Todo:
- [x] get review by Sarah
- [ ] cleanup the code a bit
- [ ] add on/off setting?

Tested to work with:
- Safari on macOS 13.1
- Firefox 108.0.1  on macOS 13.1
- Chrome 108.0.5359.124 on macOS 13.1